### PR TITLE
Fixed NullPointerException on fresh directory

### DIFF
--- a/src/main/java/com/tterrag/k9/mappings/MappingDownloader.java
+++ b/src/main/java/com/tterrag/k9/mappings/MappingDownloader.java
@@ -81,16 +81,18 @@ public abstract class MappingDownloader<M extends Mapping, T extends MappingData
         if (!hasCleanedUp) {
             synchronized (MappingDownloader.class) {
                 File[] folders = dataFolder.toFile().listFiles();
-                for (File folder : folders) {
-                    if (folder.isDirectory()) {
-                        File versionfile = new File(folder, VERSION_FILE);
-                        if (!versionfile.exists()) {
-                            log.info("Deleting outdated data found in " + folder);
-                            FileUtils.deleteDirectory(folder);
+                if (folders != null) {
+                    for (File folder : folders) {
+                        if (folder.isDirectory()) {
+                            File versionfile = new File(folder, VERSION_FILE);
+                            if (!versionfile.exists()) {
+                                log.info("Deleting outdated data found in " + folder);
+                                FileUtils.deleteDirectory(folder);
+                            }
+                        } else {
+                            log.warn("Found unknown file " + folder + " in data folder. Deleting!");
+                            folder.delete();
                         }
-                    } else {
-                        log.warn("Found unknown file " + folder + " in data folder. Deleting!");
-                        folder.delete();
                     }
                 }
                 hasCleanedUp = true;


### PR DESCRIPTION
When starting K9 in a fresh directory the MCPMapping download throws a NullPointerException.
The log of it is here: https://haste.gorymoon.se/ubinerimoh.log


This fixes is by adding a nullcheck to the removal of old data.
Code following that part generate the data folder if needed.