### PR TITLE
Add support for official mappings

### DIFF
--- a/src/main/java/com/tterrag/k9/K9.java
+++ b/src/main/java/com/tterrag/k9/K9.java
@@ -24,6 +24,7 @@ import com.tterrag.k9.listeners.IncrementListener;
 import com.tterrag.k9.logging.PrettifyMessageCreate;
 import com.tterrag.k9.mappings.Yarn2McpService;
 import com.tterrag.k9.mappings.mcp.McpDownloader;
+import com.tterrag.k9.mappings.official.OfficialDownloader;
 import com.tterrag.k9.mappings.yarn.YarnDownloader;
 import com.tterrag.k9.util.ConvertAdmins;
 import com.tterrag.k9.util.PaginatedMessageFactory;
@@ -182,7 +183,8 @@ public class K9 {
                     .doOnNext(EnderIOListener.INSTANCE::onMessage))
             */
             .service("Yarn Downloader", YarnDownloader.INSTANCE::start)
-            .service("MCP Downloader", McpDownloader.INSTANCE::start);
+            .service("MCP Downloader", McpDownloader.INSTANCE::start)
+            .service("Official Downloader", OfficialDownloader.INSTANCE::start);
 
         if (args.yarn2mcpOutput != null) {
             final Yarn2McpService yarn2mcp = new Yarn2McpService(args.yarn2mcpOutput, args.yarn2mcpUser, args.yarn2mcpPass);

--- a/src/main/java/com/tterrag/k9/commands/CommandMCP.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandMCP.java
@@ -20,7 +20,7 @@ public class CommandMCP extends CommandMappings<@NonNull McpMapping> {
     }
 
     protected CommandMCP(String name) {
-        super(name, COLOR, McpDownloader.INSTANCE);
+        super(name, name, COLOR, McpDownloader.INSTANCE);
     }
 
     protected CommandMCP(CommandMappings<@NonNull McpMapping> parent, MappingType type) {

--- a/src/main/java/com/tterrag/k9/commands/CommandMCP.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandMCP.java
@@ -1,5 +1,6 @@
 package com.tterrag.k9.commands;
 
+import com.google.common.collect.ImmutableSet;
 import com.tterrag.k9.commands.api.Command;
 import com.tterrag.k9.commands.api.CommandContext;
 import com.tterrag.k9.listeners.CommandListener;
@@ -20,7 +21,7 @@ public class CommandMCP extends CommandMappings<@NonNull McpMapping> {
     }
 
     protected CommandMCP(String name) {
-        super(name, COLOR, McpDownloader.INSTANCE);
+        super(name, ImmutableSet.of("m"), COLOR, McpDownloader.INSTANCE);
     }
 
     protected CommandMCP(CommandMappings<@NonNull McpMapping> parent, MappingType type) {

--- a/src/main/java/com/tterrag/k9/commands/CommandMCP.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandMCP.java
@@ -1,6 +1,5 @@
 package com.tterrag.k9.commands;
 
-import com.google.common.collect.ImmutableSet;
 import com.tterrag.k9.commands.api.Command;
 import com.tterrag.k9.commands.api.CommandContext;
 import com.tterrag.k9.listeners.CommandListener;
@@ -21,7 +20,7 @@ public class CommandMCP extends CommandMappings<@NonNull McpMapping> {
     }
 
     protected CommandMCP(String name) {
-        super(name, ImmutableSet.of("m"), COLOR, McpDownloader.INSTANCE);
+        super(name, COLOR, McpDownloader.INSTANCE);
     }
 
     protected CommandMCP(CommandMappings<@NonNull McpMapping> parent, MappingType type) {

--- a/src/main/java/com/tterrag/k9/commands/CommandMappings.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandMappings.java
@@ -65,12 +65,12 @@ public abstract class CommandMappings<@NonNull M extends Mapping> extends Comman
     private final int color;
     private final MappingDownloader<M, ?> downloader;
 
-    protected CommandMappings(String name, int color, MappingDownloader<M, ? extends MappingDatabase<M>> downloader) {
+    protected CommandMappings(String name, String displayName, int color, MappingDownloader<M, ? extends MappingDatabase<M>> downloader) {
         super(name.toLowerCase(Locale.ROOT), false, () -> "");
         MAPPINGS_MAP.put(name.toLowerCase(Locale.ROOT), this);
         this.parent = null;
         this.type = null;
-        this.name = name;
+        this.name = displayName;
         this.color = color;
         this.downloader = downloader;
     }

--- a/src/main/java/com/tterrag/k9/commands/CommandMappings.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandMappings.java
@@ -65,12 +65,9 @@ public abstract class CommandMappings<@NonNull M extends Mapping> extends Comman
     private final int color;
     private final MappingDownloader<M, ?> downloader;
 
-    protected CommandMappings(String name, Collection<String> conversions, int color, MappingDownloader<M, ? extends MappingDatabase<M>> downloader) {
+    protected CommandMappings(String name, int color, MappingDownloader<M, ? extends MappingDatabase<M>> downloader) {
         super(name.toLowerCase(Locale.ROOT), false, () -> "");
         MAPPINGS_MAP.put(name.toLowerCase(Locale.ROOT), this);
-        for (String conversion : conversions) {
-            MAPPINGS_MAP.put(conversion.toLowerCase(Locale.ROOT), this);
-        }
         this.parent = null;
         this.type = null;
         this.name = name;
@@ -171,18 +168,7 @@ public abstract class CommandMappings<@NonNull M extends Mapping> extends Comman
 
     @Nullable
     private CommandMappings<?> getOtherCommand(String convertTo) {
-        int maxLength = -1;
-        CommandMappings<?> otherCommand = null;
-        String lowercase = convertTo.toLowerCase(Locale.ROOT);
-        for (Map.Entry<String, CommandMappings<?>> entry : MAPPINGS_MAP.entrySet()) {
-            String key = entry.getKey();
-            if (lowercase.startsWith(key) && key.length() > maxLength) {
-                maxLength = key.length();
-                otherCommand = entry.getValue();
-            }
-        }
-        // This finds the command that matches most completely (e.g. "mm" over "m")
-        return otherCommand;
+        return MAPPINGS_MAP.get(convertTo.toLowerCase(Locale.ROOT));
     }
 
     @Override

--- a/src/main/java/com/tterrag/k9/commands/CommandOfficial.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandOfficial.java
@@ -1,0 +1,41 @@
+package com.tterrag.k9.commands;
+
+import com.google.common.collect.ImmutableSet;
+import com.tterrag.k9.commands.api.Command;
+import com.tterrag.k9.commands.api.CommandContext;
+import com.tterrag.k9.listeners.CommandListener;
+import com.tterrag.k9.mappings.MappingType;
+import com.tterrag.k9.mappings.official.OfficialDownloader;
+import com.tterrag.k9.mappings.official.OfficialMapping;
+import com.tterrag.k9.util.annotation.NonNull;
+import reactor.core.publisher.Mono;
+
+@Command
+public class CommandOfficial extends CommandMappings<@NonNull OfficialMapping> {
+    static final int COLOR = 0xFFFFFF;
+
+    public CommandOfficial() {
+        super("Official", ImmutableSet.of("moj", "mm"), COLOR, OfficialDownloader.INSTANCE);
+    }
+
+    protected CommandOfficial(CommandMappings<@NonNull OfficialMapping> parent, MappingType type) {
+        super("official", parent, type);
+    }
+
+    @Override
+    protected CommandMappings<@NonNull OfficialMapping> createChild(MappingType type) {
+        return new CommandOfficial(this, type);
+    }
+    
+    @Override
+    public Mono<?> process(CommandContext ctx) {
+        String name = ctx.getArgOrElse(ARG_NAME, "");
+        if (name.startsWith("func_") && this.type != null && this.type != MappingType.METHOD) {
+            return ctx.reply("The name `" + name + "` looks like a method. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + "officialm`?");
+        }
+        if (name.startsWith("field_") && this.type != null && this.type != MappingType.FIELD) {
+            return ctx.reply("The name `" + name + "` looks like a field. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + "officialf`?");
+        }
+        return super.process(ctx);
+    }
+}

--- a/src/main/java/com/tterrag/k9/commands/CommandOfficial.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandOfficial.java
@@ -1,6 +1,5 @@
 package com.tterrag.k9.commands;
 
-import com.google.common.collect.ImmutableSet;
 import com.tterrag.k9.commands.api.Command;
 import com.tterrag.k9.commands.api.CommandContext;
 import com.tterrag.k9.listeners.CommandListener;
@@ -15,7 +14,7 @@ public class CommandOfficial extends CommandMappings<@NonNull OfficialMapping> {
     static final int COLOR = 0xFFFFFF;
 
     public CommandOfficial() {
-        super("Official", ImmutableSet.of("moj", "mm"), COLOR, OfficialDownloader.INSTANCE);
+        super("Official", COLOR, OfficialDownloader.INSTANCE);
     }
 
     protected CommandOfficial(CommandMappings<@NonNull OfficialMapping> parent, MappingType type) {

--- a/src/main/java/com/tterrag/k9/commands/CommandOfficial.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandOfficial.java
@@ -14,11 +14,11 @@ public class CommandOfficial extends CommandMappings<@NonNull OfficialMapping> {
     static final int COLOR = 0xFFFFFF;
 
     public CommandOfficial() {
-        super("Official", COLOR, OfficialDownloader.INSTANCE);
+        super("moj", "Mojang", COLOR, OfficialDownloader.INSTANCE);
     }
 
     protected CommandOfficial(CommandMappings<@NonNull OfficialMapping> parent, MappingType type) {
-        super("official", parent, type);
+        super("moj", parent, type);
     }
 
     @Override

--- a/src/main/java/com/tterrag/k9/commands/CommandYarn.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandYarn.java
@@ -16,7 +16,7 @@ public class CommandYarn extends CommandMappings<@NonNull TinyMapping> {
     static final int COLOR = 0xDBD0B4;
     
     public CommandYarn() {
-        super("Yarn", COLOR, YarnDownloader.INSTANCE);
+        super("yarn", "Yarn", COLOR, YarnDownloader.INSTANCE);
     }
 
     protected CommandYarn(CommandMappings<@NonNull TinyMapping> parent, MappingType type) {

--- a/src/main/java/com/tterrag/k9/commands/CommandYarn.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandYarn.java
@@ -1,5 +1,6 @@
 package com.tterrag.k9.commands;
 
+import com.google.common.collect.ImmutableSet;
 import com.tterrag.k9.commands.api.Command;
 import com.tterrag.k9.commands.api.CommandContext;
 import com.tterrag.k9.listeners.CommandListener;
@@ -16,7 +17,7 @@ public class CommandYarn extends CommandMappings<@NonNull TinyMapping> {
     static final int COLOR = 0xDBD0B4;
     
     public CommandYarn() {
-        super("Yarn", COLOR, YarnDownloader.INSTANCE);
+        super("Yarn", ImmutableSet.of("y"), COLOR, YarnDownloader.INSTANCE);
     }
 
     protected CommandYarn(CommandMappings<@NonNull TinyMapping> parent, MappingType type) {

--- a/src/main/java/com/tterrag/k9/commands/CommandYarn.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandYarn.java
@@ -1,6 +1,5 @@
 package com.tterrag.k9.commands;
 
-import com.google.common.collect.ImmutableSet;
 import com.tterrag.k9.commands.api.Command;
 import com.tterrag.k9.commands.api.CommandContext;
 import com.tterrag.k9.listeners.CommandListener;
@@ -17,7 +16,7 @@ public class CommandYarn extends CommandMappings<@NonNull TinyMapping> {
     static final int COLOR = 0xDBD0B4;
     
     public CommandYarn() {
-        super("Yarn", ImmutableSet.of("y"), COLOR, YarnDownloader.INSTANCE);
+        super("Yarn", COLOR, YarnDownloader.INSTANCE);
     }
 
     protected CommandYarn(CommandMappings<@NonNull TinyMapping> parent, MappingType type) {

--- a/src/main/java/com/tterrag/k9/mappings/Mapping.java
+++ b/src/main/java/com/tterrag/k9/mappings/Mapping.java
@@ -55,9 +55,10 @@ public interface Mapping {
 
     default <T extends Mapping> Optional<? extends T> convert(MappingDatabase<? extends T> db) {
         String owner = getOwner(NameType.ORIGINAL);
+        String desc = getDesc(NameType.ORIGINAL);
         return db.lookup(NameType.ORIGINAL, getType(), owner == null ? getOriginal() : owner + "." + getOriginal())
                 .stream()
-                .filter(m -> Objects.equals(getDesc(NameType.ORIGINAL), m.getDesc(NameType.ORIGINAL)))
+                .filter(m -> Objects.equals(desc, m.getDesc(NameType.ORIGINAL)))
                 .findFirst();
     }
 }

--- a/src/main/java/com/tterrag/k9/mappings/mcp/McpMapping.java
+++ b/src/main/java/com/tterrag/k9/mappings/mcp/McpMapping.java
@@ -53,22 +53,23 @@ public interface McpMapping extends IntermediateMapping, CommentedMapping {
             String atName = getIntermediate();
             if (getType() == MappingType.CLASS) {
                 atName = atName.replace('/', '.');
+            } else {
+                // If this is a class, then getOwner() is empty meaning we shouldn't add another space
+                builder.append(' ');
             }
-            builder.append(" ").append(atName);
+            builder.append(atName);
             String desc = getDesc();
             if (desc != null) {
-                builder.append(getDesc());
+                builder.append(desc);
             }
             if (getType() != MappingType.CLASS) {
-                Mapping parent = getParent();
-                String parentMcp = parent.getName();
-                builder.append(" # ").append(parentMcp == null ? parent.getIntermediate() : parentMcp);
+                builder.append(" # ").append(getName() == null ? getIntermediate() : getName());
             }
             builder.append("`");
         }
         String type = getMemberClass();
         if (type != null) {
-            builder.append("\n__Type__: `" + type + "`");
+            builder.append("\n__Type__: `").append(type).append("`");
         }
         return builder.toString();
     }

--- a/src/main/java/com/tterrag/k9/mappings/mcp/McpMapping.java
+++ b/src/main/java/com/tterrag/k9/mappings/mcp/McpMapping.java
@@ -54,7 +54,7 @@ public interface McpMapping extends IntermediateMapping, CommentedMapping {
             if (getType() == MappingType.CLASS) {
                 atName = atName.replace('/', '.');
             } else {
-                // If this is a class, then getOwner() is empty meaning we shouldn't add another space
+                // If this is a class, then getOwner() is empty meaning we should only add a space if it isn't a class
                 builder.append(' ');
             }
             builder.append(atName);

--- a/src/main/java/com/tterrag/k9/mappings/mcp/SrgDatabase.java
+++ b/src/main/java/com/tterrag/k9/mappings/mcp/SrgDatabase.java
@@ -5,16 +5,12 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
 import com.tterrag.k9.mappings.MappingType;
 import com.tterrag.k9.mappings.NameType;
 import com.tterrag.k9.mappings.NoSuchVersionException;
@@ -24,17 +20,8 @@ import com.tterrag.k9.util.annotation.NonNull;
 
 public class SrgDatabase extends OverrideRemovingDatabase<SrgMapping> {
 
-    private final Map<String, SrgMapping> classMap = new HashMap<>();
-    private final ListMultimap<String, SrgMapping> childrenMap = ArrayListMultimap.create();
-    private final boolean populateMaps;
-
     public SrgDatabase(String mcver) throws NoSuchVersionException {
-        this(mcver, false);
-    }
-
-    public SrgDatabase(String mcver, boolean populateMaps) throws NoSuchVersionException {
         super(mcver);
-        this.populateMaps = populateMaps;
     }
 
     @Override
@@ -54,18 +41,6 @@ public class SrgDatabase extends OverrideRemovingDatabase<SrgMapping> {
         try (ZipFile zipfile = new ZipFile(zip)) {
             return parser.parse(zipfile);
         }
-    }
-
-    @Override
-    protected boolean addMapping(SrgMapping mapping) {
-        if (populateMaps) {
-            if (mapping.getType() == MappingType.CLASS) {
-                classMap.put(mapping.getOriginal(), mapping);
-            } else {
-                childrenMap.put(mapping.getOwner(NameType.ORIGINAL), mapping);
-            }
-        }
-        return super.addMapping(mapping);
     }
 
     @NonNull
@@ -92,13 +67,5 @@ public class SrgDatabase extends OverrideRemovingDatabase<SrgMapping> {
             return NullHelper.notnullJ(found, "Stream#collect");
         }
         return ret;
-    }
-
-    public SrgMapping getClassMapping(String original) {
-        return classMap.get(original);
-    }
-
-    public List<SrgMapping> getChildren(String owner) {
-        return childrenMap.get(owner);
     }
 }

--- a/src/main/java/com/tterrag/k9/mappings/official/FastSrgDatabase.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/FastSrgDatabase.java
@@ -1,0 +1,41 @@
+package com.tterrag.k9.mappings.official;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.tterrag.k9.mappings.MappingType;
+import com.tterrag.k9.mappings.NameType;
+import com.tterrag.k9.mappings.NoSuchVersionException;
+import com.tterrag.k9.mappings.mcp.SrgDatabase;
+import com.tterrag.k9.mappings.mcp.SrgMapping;
+
+public class FastSrgDatabase extends SrgDatabase {
+
+    private final Map<String, SrgMapping> classMap = new HashMap<>();
+    private final ListMultimap<String, SrgMapping> childrenMap = ArrayListMultimap.create();
+
+    public FastSrgDatabase(String mcver) throws NoSuchVersionException {
+        super(mcver);
+    }    
+
+    @Override
+    protected boolean addMapping(SrgMapping mapping) {
+        if (mapping.getType() == MappingType.CLASS) {
+            classMap.put(mapping.getOriginal(), mapping);
+        } else {
+            childrenMap.put(mapping.getOwner(NameType.ORIGINAL), mapping);
+        }
+        return super.addMapping(mapping);
+    }
+
+    public SrgMapping getClassMapping(String original) {
+        return classMap.get(original);
+    }
+
+    public List<SrgMapping> getChildren(String owner) {
+        return childrenMap.get(owner);
+    }
+}

--- a/src/main/java/com/tterrag/k9/mappings/official/ManifestJson.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/ManifestJson.java
@@ -1,0 +1,71 @@
+package com.tterrag.k9.mappings.official;
+
+import com.google.gson.Gson;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Data
+@Setter(AccessLevel.NONE)
+public class ManifestJson {
+    public LatestInfo latest;
+    public VersionInfo[] versions;
+
+    @Data
+    @Setter(AccessLevel.NONE)
+    public static class LatestInfo {
+        private String release;
+        private String snapshot;
+    }
+
+    @Data
+    @Setter(AccessLevel.NONE)
+    public static class VersionInfo {
+        private String id;
+        private String type;
+        private URL url;
+
+        public boolean isRelease() {
+            return "release".equals(type);
+        }
+
+        public boolean isSnapshot() {
+            return "snapshot".equals(type);
+        }
+
+        public Mono<VersionJson> getJson(Gson gson) {
+            return HttpClient.create()
+                    .get()
+                    .uri(url.toString())
+                    .responseSingle(($, content) -> content.asString()
+                            .map(s -> gson.fromJson(s, VersionJson.class)));
+        }
+    }
+
+    public VersionInfo getVersionInfo(String versionId) {
+        for (VersionInfo info : versions) {
+            if (info.id.equals(versionId))
+                return info;
+        }
+        return null;
+    }
+
+    public Set<VersionInfo> getAllVersions() {
+        return Arrays.stream(versions).collect(Collectors.toSet());
+    }
+
+    public Set<VersionInfo> getReleaseVersions() {
+        return Arrays.stream(versions).filter(VersionInfo::isRelease).collect(Collectors.toSet());
+    }
+
+    public Set<VersionInfo> getSnapshotVersions() {
+        return Arrays.stream(versions).filter(VersionInfo::isSnapshot).collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialDatabase.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialDatabase.java
@@ -1,13 +1,5 @@
 package com.tterrag.k9.mappings.official;
 
-import com.beust.jcommander.internal.Lists;
-import com.tterrag.k9.mappings.AbstractMappingDatabase;
-import com.tterrag.k9.mappings.Mapping;
-import com.tterrag.k9.mappings.MappingType;
-import com.tterrag.k9.mappings.NoSuchVersionException;
-import com.tterrag.k9.mappings.mcp.McpMapping;
-import com.tterrag.k9.mappings.mcp.SrgDatabase;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,8 +12,15 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.beust.jcommander.internal.Lists;
+import com.tterrag.k9.mappings.AbstractMappingDatabase;
+import com.tterrag.k9.mappings.Mapping;
+import com.tterrag.k9.mappings.MappingType;
+import com.tterrag.k9.mappings.NoSuchVersionException;
+import com.tterrag.k9.mappings.mcp.McpMapping;
+
 public class OfficialDatabase extends AbstractMappingDatabase<OfficialMapping> {
-    private final SrgDatabase srgs = new SrgDatabase(getMinecraftVersion(), true);
+    private final FastSrgDatabase srgs = new FastSrgDatabase(getMinecraftVersion());
 
     public OfficialDatabase(String minecraftVersion) {
         super(minecraftVersion);

--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialDatabase.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialDatabase.java
@@ -1,0 +1,118 @@
+package com.tterrag.k9.mappings.official;
+
+import com.beust.jcommander.internal.Lists;
+import com.tterrag.k9.mappings.AbstractMappingDatabase;
+import com.tterrag.k9.mappings.MappingType;
+import com.tterrag.k9.mappings.NoSuchVersionException;
+import com.tterrag.k9.mappings.mcp.McpMapping;
+import com.tterrag.k9.mappings.mcp.SrgDatabase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class OfficialDatabase extends AbstractMappingDatabase<OfficialMapping> {
+    private final SrgDatabase srgs = new SrgDatabase(getMinecraftVersion());
+
+    public OfficialDatabase(String minecraftVersion) {
+        super(minecraftVersion);
+    }
+
+    @Override
+    protected Collection<OfficialMapping> parseMappings() throws NoSuchVersionException, IOException {
+        srgs.reload();
+
+        String mcver = getMinecraftVersion();
+        Path mappingsFolder = OfficialDownloader.INSTANCE.getDataFolder().resolve(Paths.get(mcver, "mappings"));
+
+        return this.parse(mappingsFolder.resolve("client.txt"), mappingsFolder.resolve("server.txt"));
+    }
+
+    public Collection<OfficialMapping> parse(Path client, Path server) throws IOException {
+        Set<OfficialMapping> mappings = new HashSet<>();
+        for (Path path : Lists.newArrayList(client, server)) {
+            List<String> lines = Files.readAllLines(path).stream()
+                    .filter(s -> !s.startsWith("#"))
+                    .map(s -> s.replace('.', '/'))
+                    .collect(Collectors.toList());
+            populateMappings(mappings, lines, "client.txt".equals(path.getFileName().toString()));
+        }
+        return mappings;
+    }
+
+    // Derived from SrgUtils in InternalUtils#loadProguard
+    private void populateMappings(Set<OfficialMapping> mappings, List<String> lines, boolean isClient) throws IOException {
+        McpMapping.Side side = isClient ? McpMapping.Side.CLIENT : McpMapping.Side.SERVER;
+        OfficialMapping clazz = null;
+        for (String line : lines) {
+            if (!line.startsWith("    ") && line.endsWith(":")) {
+                String[] mapped = line.substring(0, line.length() - 1).split(" -> ");
+                clazz = addMapping(mappings, new OfficialMapping(srgs, this, side, MappingType.CLASS, null, null, mapped[1], mapped[0], null));
+            } else if (line.contains("(") && line.contains(")")) {
+                if (clazz == null)
+                    throw new IOException("Class was null when parsing method");
+
+                line = line.trim();
+                if (line.indexOf(':') != -1) {
+                    int i = line.indexOf(':');
+                    int j = line.indexOf(':', i + 1);
+                    line = line.substring(j + 1);
+                }
+
+                String original = line.split(" -> ")[1];
+                int spaceIndex = line.indexOf(' ');
+                String returnType = toDesc(line.substring(0, spaceIndex));
+                String name = line.substring(spaceIndex + 1, line.indexOf('('));
+                String[] args = line.substring(line.indexOf('(') + 1, line.indexOf(')')).split(",");
+
+                StringBuilder desc = new StringBuilder("(");
+                for (String arg : args) {
+                    if (arg.isEmpty())
+                        break;
+                    desc.append(toDesc(arg));
+                }
+                desc.append(')').append(returnType);
+                addMapping(mappings, new OfficialMapping(srgs, this, side, MappingType.METHOD, clazz, desc.toString(), original, name, null));
+            } else {
+                if (clazz == null)
+                    throw new IOException("Class was null when parsing field");
+
+                String[] pts = line.trim().split(" ");
+                addMapping(mappings, new OfficialMapping(srgs, this, side, MappingType.FIELD, clazz, null, pts[3], pts[1], pts[0]));
+            }
+        }
+    }
+
+    private OfficialMapping addMapping(Set<OfficialMapping> mappings, OfficialMapping toAdd) {
+        OfficialMapping toReturn = toAdd;
+        if (!mappings.add(toAdd)) {
+            mappings.remove(toAdd);
+            toReturn = toAdd.cloneWithSide(McpMapping.Side.BOTH);
+            mappings.add(toReturn);
+        }
+        return toReturn;
+    }
+
+    // Copied from SrgUtils in InternalUtils#toDesc
+    // TODO convert to use clojure types??
+    private static String toDesc(String type) {
+        if (type.endsWith("[]"))    return "[" + toDesc(type.substring(0, type.length() - 2));
+        if (type.equals("int"))     return "I";
+        if (type.equals("void"))    return "V";
+        if (type.equals("boolean")) return "Z";
+        if (type.equals("byte"))    return "B";
+        if (type.equals("char"))    return "C";
+        if (type.equals("short"))   return "S";
+        if (type.equals("double"))  return "D";
+        if (type.equals("float"))   return "F";
+        if (type.equals("long"))    return "J";
+        if (type.contains("/"))     return "L" + type + ";";
+        throw new RuntimeException("Invalid toDesc input: " + type);
+    }
+}

--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialDownloader.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialDownloader.java
@@ -1,0 +1,88 @@
+package com.tterrag.k9.mappings.official;
+
+import com.beust.jcommander.internal.Lists;
+import com.tterrag.k9.mappings.MappingDownloader;
+import com.tterrag.k9.util.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class OfficialDownloader extends MappingDownloader<OfficialMapping, OfficialDatabase> {
+    public static final OfficialDownloader INSTANCE = new OfficialDownloader();
+    private static final String MANIFEST_JSON = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
+
+    private OfficialDownloader() {
+        super("official", OfficialDatabase::new, 1);
+    }
+
+    @Nullable
+    private ManifestJson manifest;
+
+    @Override
+    protected Set<String> getMinecraftVersionsInternal() {
+        return manifest.getReleaseVersions().stream().map(ManifestJson.VersionInfo::getId).collect(Collectors.toSet());
+    }
+
+    @Override
+    protected String getLatestMinecraftVersionInternal(boolean stable) {
+        return manifest.getLatest().getRelease();
+    }
+
+    private Mono<ManifestJson> getManifestJson() {
+        return HttpClient.create()
+                .get()
+                .uri(MANIFEST_JSON)
+                .responseSingle(($, content) -> content.asString()
+                        .map(s -> getGson().fromJson(s, ManifestJson.class)));
+    }
+
+    @Override
+    protected Mono<Void> updateVersions() {
+        return Mono.fromRunnable(() -> log.info("Running Official mappings update check..."))
+                .then(this.getManifestJson())
+                .doOnNext(m -> this.manifest = m)
+                .then();
+    }
+
+    @Override
+    protected Mono<Void> checkUpdates(String version) {
+        return updateVersions().then(Mono.fromSupplier(() -> this.manifest))
+                .flatMap(m -> Mono.justOrEmpty(m.getVersionInfo(version)))
+                .flatMap(m -> m.getJson(getGson()))
+                .flatMap(versionJson -> Mono.fromCallable(() -> {
+                    Path versionFolder = getDataFolder().resolve(version);
+                    File mappingsFolder = versionFolder.resolve("mappings").toFile();
+                    URL clientUrl = versionJson.getDownloads().get("client_mappings").getUrl();
+                    URL serverUrl = versionJson.getDownloads().get("server_mappings").getUrl();
+                    List<URL> mappingUrls = Lists.newArrayList(clientUrl, serverUrl);
+
+                    if (!mappingsFolder.exists()) {
+                        mappingsFolder.mkdirs();
+                    }
+
+                    File[] folderContents = mappingsFolder.listFiles();
+                    if (folderContents != null && folderContents.length > 0) {
+                        log.debug("Official MC {} mappings up to date", version);
+                        return null;
+                    }
+
+                    log.info("Found missing Official mappings for MC {}. Downloading.", version);
+                    for (URL mappingsUrl : mappingUrls) {
+                        String filename = mappingsUrl.getPath().substring(mappingsUrl.getPath().lastIndexOf('/') + 1);
+                        FileUtils.copyURLToFile(mappingsUrl, new File(mappingsFolder, filename));
+                    }
+                    remove(version);
+
+                    return null;
+                }));
+    }
+}

--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
@@ -1,0 +1,122 @@
+package com.tterrag.k9.mappings.official;
+
+import clojure.asm.Type;
+import com.google.common.base.Strings;
+import com.tterrag.k9.mappings.Mapping;
+import com.tterrag.k9.mappings.MappingType;
+import com.tterrag.k9.mappings.NameType;
+import com.tterrag.k9.mappings.SignatureHelper;
+import com.tterrag.k9.mappings.mcp.McpMapping;
+import com.tterrag.k9.mappings.mcp.SrgDatabase;
+import com.tterrag.k9.util.annotation.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+@Value
+@RequiredArgsConstructor
+@EqualsAndHashCode(of = {"type", "owner", "original", "name"})
+@ToString(doNotUseGetters = true)
+public class OfficialMapping implements Mapping {
+    private static final SignatureHelper sigHelper = new SignatureHelper();
+
+    @ToString.Exclude
+    protected final transient SrgDatabase srgs;
+    @ToString.Exclude
+    protected final transient OfficialDatabase db;
+
+    private final McpMapping.Side side;
+
+    @Getter(onMethod = @__(@Override))
+    private final MappingType type;
+
+    private final Mapping owner;
+
+    private final String desc;
+
+    @Getter(onMethod = @__(@Override))
+    private final String original, name, memberClass;
+
+    @ToString.Exclude
+    private final transient Map<NameType, String> mappedOwner = new EnumMap<>(NameType.class), mappedDesc = new EnumMap<>(NameType.class);
+
+    @NonFinal
+    private String intermediate = null;
+
+    @Override
+    public String formatMessage(String mcver) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("\n");
+        builder.append("**MC " + mcver + ": " + (owner == null ? "" : owner.getName() + ".") + name + "**\n");
+        String intermediate = getIntermediate();
+        builder.append("__Name__: `" + original + (intermediate.isEmpty() ? "" : "` => `" + intermediate) + "` => `" + name + "`\n");
+
+        builder.append("__Side__: `" + side + "`");
+
+        if (getType() != MappingType.PARAM && !intermediate.isEmpty()) {
+            builder.append("\n__AT__: `public ").append(Strings.nullToEmpty(getOwner(NameType.INTERMEDIATE)).replace('/', '.'));
+            String atName = intermediate;
+            if (getType() == MappingType.CLASS) {
+                atName = atName.replace('/', '.');
+            } else {
+                // If this is a class, then getOwner() is empty meaning we shouldn't add another space
+                builder.append(' ');
+            }
+            builder.append(atName);
+            String desc = getDesc();
+            if (desc != null) {
+                builder.append(desc);
+            }
+            if (getType() != MappingType.CLASS) {
+                builder.append(" # ").append(getName() == null ? intermediate : getName());
+            }
+            builder.append("`");
+        }
+
+        if (getMemberClass() != null)
+            builder.append("\n__Type__: `").append(getMemberClass()).append("`");
+
+        return builder.toString();
+    }
+
+    OfficialMapping cloneWithSide(McpMapping.Side side) {
+        return new OfficialMapping(srgs, db, side, type, owner, desc, original, name, memberClass);
+    }
+
+    @Override
+    public @Nullable String getOwner() {
+        return getOwner(NameType.NAME);
+    }
+
+    @Override
+    public @Nullable String getOwner(NameType name) {
+        return mappedOwner.computeIfAbsent(name, t -> owner == null ? null : sigHelper.mapType(t, owner.getOriginal(), this, db).getInternalName());
+    }
+
+    private String mapType(NameType t, String type) {
+        return sigHelper.mapType(t, Type.getType(type), this, db).getDescriptor();
+    }
+
+    @Override
+    public String getDesc(NameType name) {
+        return mappedDesc.computeIfAbsent(name, t -> desc == null ? null : desc.contains("(") ? sigHelper.mapSignature(t, desc, this, db) : mapType(t, desc));
+    }
+
+    @Override
+    public String getIntermediate() {
+        if (intermediate != null)
+            return intermediate;
+        if (getType() == MappingType.CLASS) {
+            intermediate = convert(srgs).map(Mapping::getIntermediate).orElse("");
+        } else {
+            intermediate = convert(srgs).map(Mapping.class::cast).orElse(owner).getIntermediate();
+        }
+        return intermediate;
+    }
+}

--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
@@ -1,6 +1,9 @@
 package com.tterrag.k9.mappings.official;
 
-import clojure.asm.Type;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
+
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.tterrag.k9.mappings.Mapping;
@@ -8,8 +11,9 @@ import com.tterrag.k9.mappings.MappingType;
 import com.tterrag.k9.mappings.NameType;
 import com.tterrag.k9.mappings.SignatureHelper;
 import com.tterrag.k9.mappings.mcp.McpMapping;
-import com.tterrag.k9.mappings.mcp.SrgDatabase;
 import com.tterrag.k9.util.annotation.Nullable;
+
+import clojure.asm.Type;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -20,10 +24,6 @@ import lombok.ToString;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 
-import java.util.EnumMap;
-import java.util.Map;
-import java.util.Optional;
-
 @Value
 @RequiredArgsConstructor
 @EqualsAndHashCode(of = {"type", "owner", "original", "name"})
@@ -32,7 +32,7 @@ public class OfficialMapping implements Mapping {
     private static final SignatureHelper sigHelper = new SignatureHelper();
 
     @ToString.Exclude
-    protected final transient SrgDatabase srgs;
+    protected final transient FastSrgDatabase srgs;
     @ToString.Exclude
     protected final transient OfficialDatabase db;
 

--- a/src/main/java/com/tterrag/k9/mappings/official/VersionJson.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/VersionJson.java
@@ -1,0 +1,22 @@
+package com.tterrag.k9.mappings.official;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+
+import java.net.URL;
+import java.util.Map;
+
+@Data
+@Setter(AccessLevel.NONE)
+public class VersionJson {
+    private Map<String, Download> downloads;
+
+    @Data
+    @Setter(AccessLevel.NONE)
+    public static class Download {
+        public String sha1;
+        public int size;
+        public URL url;
+    }
+}

--- a/src/main/java/com/tterrag/k9/mappings/official/package-info.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/package-info.java
@@ -1,0 +1,6 @@
+@NonNullMethods
+@NonNullParams
+package com.tterrag.k9.mappings.official;
+
+import com.tterrag.k9.util.annotation.NonNullMethods;
+import com.tterrag.k9.util.annotation.NonNullParams;


### PR DESCRIPTION
This PR adds support for official mappings. Additionally, aliases are also added to `ICommand` with `CommandRegistrar` being updated accordingly to support them. This makes it possible to use `!mojmaps`, `!mm`, or `!official`.

I do not have the best grasp of this project, so please let me know where I could improve the code. I added a TODO where I think clojure types could be used instead of manual conversion, but I didn't figure out how.