### PR TITLE
Add `mappings-latest` function to Clojure sandbox

### DIFF
--- a/src/main/java/com/tterrag/k9/commands/CommandMappings.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandMappings.java
@@ -31,6 +31,7 @@ import com.tterrag.k9.util.annotation.NonNull;
 
 import com.tterrag.k9.util.annotation.Nullable;
 import discord4j.rest.util.Permission;
+import lombok.Getter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -69,6 +70,7 @@ public abstract class CommandMappings<@NonNull M extends Mapping> extends Comman
     
     private final String name;
     private final int color;
+    @Getter
     private final MappingDownloader<M, ?> downloader;
 
     protected CommandMappings(String name, String displayName, int color, MappingDownloader<M, ? extends MappingDatabase<M>> downloader) {
@@ -89,7 +91,19 @@ public abstract class CommandMappings<@NonNull M extends Mapping> extends Comman
         this.color = parent.color;
         this.downloader = parent.downloader;
     }
-    
+
+    public static CommandMappings<?> getMappingsCommand(String channel) {
+        switch (channel.toLowerCase(Locale.ROOT)) {
+            case "stable":
+            case "snapshot":
+                return MAPPINGS_MAP.get("mcp");
+            case "official":
+                return MAPPINGS_MAP.get("moj");
+            default:
+                return null;
+        }
+    }
+
     protected abstract CommandMappings<M> createChild(MappingType type);
     
     @Override
@@ -119,7 +133,7 @@ public abstract class CommandMappings<@NonNull M extends Mapping> extends Comman
         }
     }
 
-    protected Mono<String> getMcVersion(CommandContext ctx) {
+    public Mono<String> getMcVersion(CommandContext ctx) {
         return ctx.getArgOrElse(ARG_VERSION, Mono.fromSupplier(() -> storage.get(ctx).orElse(null))
                 .filter(s -> !s.isEmpty())
                 .switchIfEmpty(downloader.getLatestMinecraftVersion(false)));

--- a/src/main/java/com/tterrag/k9/mappings/MappingDownloader.java
+++ b/src/main/java/com/tterrag/k9/mappings/MappingDownloader.java
@@ -78,13 +78,13 @@ public abstract class MappingDownloader<M extends Mapping, T extends MappingData
     private final Object2LongMap<String> lastChecked = new Object2LongOpenHashMap<>();
 
     public static Mono<String> getLatestMinecraftVersion(String channel) {
-        if ("stable".equals(channel) || "snapshot".equals(channel)) {
-            boolean stable = "stable".equals(channel);
+        boolean stable = "stable".equalsIgnoreCase(channel);
+        if (stable || "snapshot".equalsIgnoreCase(channel)) {
             return McpDownloader.INSTANCE.getLatestMinecraftVersion(stable)
                     .zipWith(McpDownloader.INSTANCE.getVersions(), (mcver, json) -> json.getMappings(mcver).map(version ->
                             (stable ? version.latestStable() : version.latestSnapshot()) + "-" + mcver))
                     .flatMap(Mono::justOrEmpty);
-        } else if ("official".equals(channel)) {
+        } else if ("official".equalsIgnoreCase(channel)) {
             return OfficialDownloader.INSTANCE.getLatestMinecraftVersion(true);
         }
         return Mono.empty();

--- a/src/main/java/com/tterrag/k9/mappings/MappingDownloader.java
+++ b/src/main/java/com/tterrag/k9/mappings/MappingDownloader.java
@@ -13,8 +13,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.tterrag.k9.mappings.mcp.McpDownloader;
-import com.tterrag.k9.mappings.official.OfficialDownloader;
 import org.apache.commons.io.FileUtils;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -77,19 +75,6 @@ public abstract class MappingDownloader<M extends Mapping, T extends MappingData
     private volatile long lastVersionCheck;
     private final Object2LongMap<String> lastChecked = new Object2LongOpenHashMap<>();
 
-    public static Mono<String> getLatestMinecraftVersion(String channel) {
-        boolean stable = "stable".equalsIgnoreCase(channel);
-        if (stable || "snapshot".equalsIgnoreCase(channel)) {
-            return McpDownloader.INSTANCE.getLatestMinecraftVersion(stable)
-                    .zipWith(McpDownloader.INSTANCE.getVersions(), (mcver, json) -> json.getMappings(mcver).map(version ->
-                            (stable ? version.latestStable() : version.latestSnapshot()) + "-" + mcver))
-                    .flatMap(Mono::justOrEmpty);
-        } else if ("official".equalsIgnoreCase(channel)) {
-            return OfficialDownloader.INSTANCE.getLatestMinecraftVersion(true);
-        }
-        return Mono.empty();
-    }
-
     protected abstract Mono<Void> updateVersions();
     
     protected abstract Mono<Void> checkUpdates(String version);
@@ -97,6 +82,14 @@ public abstract class MappingDownloader<M extends Mapping, T extends MappingData
     protected abstract Set<String> getMinecraftVersionsInternal();
     
     protected abstract String getLatestMinecraftVersionInternal(boolean stable);
+
+    protected String getMappingsVersionInternal(String mcver, boolean stable) {
+        return mcver;
+    }
+
+    protected String getLatestMappingsVersionInternal(boolean stable) {
+        return getMappingsVersionInternal(getLatestMinecraftVersionInternal(stable), stable);
+    }
     
     protected final Mono<Void> updateVersionsIfRequired() {
         Mono<Void> updateCheck = Mono.empty();
@@ -113,6 +106,14 @@ public abstract class MappingDownloader<M extends Mapping, T extends MappingData
     
     public final Mono<String> getLatestMinecraftVersion(boolean stable) {
         return updateVersionsIfRequired().then(Mono.fromSupplier(() -> getLatestMinecraftVersionInternal(stable)));
+    }
+
+    public final Mono<String> getLatestMappingsVersion(boolean stable) {
+        return updateVersionsIfRequired().then(Mono.fromSupplier(() -> getLatestMappingsVersionInternal(stable)));
+    }
+
+    public final Mono<String> getMappingsVersion(String mcver, boolean stable) {
+        return updateVersionsIfRequired().then(Mono.fromSupplier(() -> getMappingsVersionInternal(mcver, stable)));
     }
     
     public Path getDataFolder() {

--- a/src/main/java/com/tterrag/k9/mappings/mcp/McpDownloader.java
+++ b/src/main/java/com/tterrag/k9/mappings/mcp/McpDownloader.java
@@ -60,11 +60,24 @@ public class McpDownloader extends MappingDownloader<McpMapping, McpDatabase> {
     }
     
     @Override
+    protected String getMappingsVersionInternal(String mcver, boolean stable) {
+        McpMappingsJson json = versions.getMappings(mcver).orElse(null);
+        if (stable && json != null && json.latestStable() == -1) {
+            mcver = getLatestMinecraftVersionInternal(true);
+            json = versions.getMappings(mcver).orElse(null);
+        }
+
+        if (json == null)
+            return "Unknown";
+        return (stable ? json.latestStable() : json.latestSnapshot()) + "-" + mcver;
+    }
+
+    @Override
     protected void collectParsers(GsonBuilder builder) {
         super.collectParsers(builder);
         DeserializeIntArrayList.register(builder);
     }
-    
+
     private Mono<McpVersionJson> getVersions(String url) {
         return HttpClient.create()
             .get()

--- a/src/main/resources/sandbox-init.clj
+++ b/src/main/resources/sandbox-init.clj
@@ -16,6 +16,8 @@
   ;; Convenience functions
   (defn codeblock [s & { type :type }] (str "```" type "\n" s "\n```"))
 
+  (defn mappings-latest [channel] (.block (com.tterrag.k9.mappings.MappingDownloader/getLatestMinecraftVersion channel)))
+
   (defn delete-self [] (.set k9.sandbox/*delete-self* true))
 
   ;; Embed utilities

--- a/src/main/resources/sandbox-init.clj
+++ b/src/main/resources/sandbox-init.clj
@@ -16,8 +16,6 @@
   ;; Convenience functions
   (defn codeblock [s & { type :type }] (str "```" type "\n" s "\n```"))
 
-  (defn mappings-latest [channel] (.block (com.tterrag.k9.mappings.MappingDownloader/getLatestMinecraftVersion channel)))
-
   (defn delete-self [] (.set k9.sandbox/*delete-self* true))
 
   ;; Embed utilities


### PR DESCRIPTION
This is a simple PR that adds a new static method to `MappingDownloader`, which takes in a channel string and outputs the latest version for that string. A function is also added to the sandbox init clojure file to support this. This is useful for a trick that I am making. I confirmed it to work in nREPL.