### PR TITLE
Clean up official mappings and other related fixes

### DIFF
--- a/src/main/java/com/tterrag/k9/commands/CommandMCP.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandMCP.java
@@ -20,7 +20,7 @@ public class CommandMCP extends CommandMappings<@NonNull McpMapping> {
     }
 
     protected CommandMCP(String name) {
-        super(name, name, COLOR, McpDownloader.INSTANCE);
+        super(name, name, false, COLOR, McpDownloader.INSTANCE);
     }
 
     protected CommandMCP(CommandMappings<@NonNull McpMapping> parent, MappingType type) {
@@ -40,10 +40,10 @@ public class CommandMCP extends CommandMappings<@NonNull McpMapping> {
     public Mono<?> process(CommandContext ctx) {
         String name = ctx.getArgOrElse(ARG_NAME, "");
         if (name.startsWith("func_") && this.type != null && this.type != MappingType.METHOD) {
-            return ctx.reply("The name `" + name + "` looks like a method. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + "mcpm`?");
+            return ctx.reply("The name `" + name + "` looks like a method. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + this.getName() + "`?");
         }
         if (name.startsWith("field_") && this.type != null && this.type != MappingType.FIELD) {
-            return ctx.reply("The name `" + name + "` looks like a field. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + "mcpf`?");
+            return ctx.reply("The name `" + name + "` looks like a field. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + this.getName() + "`?");
         }
         return super.process(ctx);
     }

--- a/src/main/java/com/tterrag/k9/commands/CommandOfficial.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandOfficial.java
@@ -14,7 +14,7 @@ public class CommandOfficial extends CommandMappings<@NonNull OfficialMapping> {
     static final int COLOR = 0xFFFFFF;
 
     public CommandOfficial() {
-        super("moj", "Mojmap", COLOR, OfficialDownloader.INSTANCE);
+        super("moj", "Mojmap", true, COLOR, OfficialDownloader.INSTANCE);
     }
 
     protected CommandOfficial(CommandMappings<@NonNull OfficialMapping> parent, MappingType type) {
@@ -30,10 +30,10 @@ public class CommandOfficial extends CommandMappings<@NonNull OfficialMapping> {
     public Mono<?> process(CommandContext ctx) {
         String name = ctx.getArgOrElse(ARG_NAME, "");
         if (name.startsWith("func_") && this.type != null && this.type != MappingType.METHOD) {
-            return ctx.reply("The name `" + name + "` looks like a method. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + "officialm`?");
+            return ctx.reply("The name `" + name + "` looks like a method. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + this.getName() + "`?");
         }
         if (name.startsWith("field_") && this.type != null && this.type != MappingType.FIELD) {
-            return ctx.reply("The name `" + name + "` looks like a field. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + "officialf`?");
+            return ctx.reply("The name `" + name + "` looks like a field. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + this.getName() + "`?");
         }
         return super.process(ctx);
     }

--- a/src/main/java/com/tterrag/k9/commands/CommandYarn.java
+++ b/src/main/java/com/tterrag/k9/commands/CommandYarn.java
@@ -16,7 +16,7 @@ public class CommandYarn extends CommandMappings<@NonNull TinyMapping> {
     static final int COLOR = 0xDBD0B4;
     
     public CommandYarn() {
-        super("yarn", "Yarn", COLOR, YarnDownloader.INSTANCE);
+        super("yarn", "Yarn", false, COLOR, YarnDownloader.INSTANCE);
     }
 
     protected CommandYarn(CommandMappings<@NonNull TinyMapping> parent, MappingType type) {
@@ -32,10 +32,10 @@ public class CommandYarn extends CommandMappings<@NonNull TinyMapping> {
     public Mono<?> process(CommandContext ctx) {
         String name = ctx.getArgOrElse(ARG_NAME, "");
         if (name.startsWith("method_") && this.type != null && this.type != MappingType.METHOD) {
-            return ctx.reply("The name `" + name + "` looks like a method. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + "ym`?");
+            return ctx.reply("The name `" + name + "` looks like a method. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + this.getName() + "`?");
         }
         if (name.startsWith("field_") && this.type != null && this.type != MappingType.FIELD) {
-            return ctx.reply("The name `" + name + "` looks like a field. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + "yf`?");
+            return ctx.reply("The name `" + name + "` looks like a field. Perhaps you meant to use `" + CommandListener.getPrefix(ctx.getGuildId()) + this.getName() + "`?");
         }
         return super.process(ctx);
     }

--- a/src/main/java/com/tterrag/k9/mappings/official/ManifestJson.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/ManifestJson.java
@@ -30,14 +30,13 @@ public class ManifestJson {
 
     @Data
     @Setter(AccessLevel.NONE)
-    @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+    @EqualsAndHashCode
     @NoArgsConstructor
     @AllArgsConstructor
     public static class VersionInfo {
-        @EqualsAndHashCode.Include
         private String id;
-        @EqualsAndHashCode.Include
         private String type;
+        @EqualsAndHashCode.Exclude
         private URL url;
 
         public boolean isRelease() {

--- a/src/main/java/com/tterrag/k9/mappings/official/ManifestJson.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/ManifestJson.java
@@ -2,14 +2,17 @@ package com.tterrag.k9.mappings.official;
 
 import com.google.gson.Gson;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 
 import java.net.URL;
 import java.util.Arrays;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Data
@@ -27,8 +30,13 @@ public class ManifestJson {
 
     @Data
     @Setter(AccessLevel.NONE)
+    @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class VersionInfo {
+        @EqualsAndHashCode.Include
         private String id;
+        @EqualsAndHashCode.Include
         private String type;
         private URL url;
 
@@ -57,15 +65,15 @@ public class ManifestJson {
         return null;
     }
 
-    public Set<VersionInfo> getAllVersions() {
-        return Arrays.stream(versions).collect(Collectors.toSet());
+    public List<String> getAllVersions() {
+        return Arrays.stream(versions).map(VersionInfo::getId).collect(Collectors.toList());
     }
 
-    public Set<VersionInfo> getReleaseVersions() {
-        return Arrays.stream(versions).filter(VersionInfo::isRelease).collect(Collectors.toSet());
+    public List<String> getReleaseVersions() {
+        return Arrays.stream(versions).filter(VersionInfo::isRelease).map(VersionInfo::getId).collect(Collectors.toList());
     }
 
-    public Set<VersionInfo> getSnapshotVersions() {
-        return Arrays.stream(versions).filter(VersionInfo::isSnapshot).collect(Collectors.toSet());
+    public List<String> getSnapshotVersions() {
+        return Arrays.stream(versions).filter(VersionInfo::isSnapshot).map(VersionInfo::getId).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
@@ -70,9 +70,7 @@ public class OfficialMapping implements Mapping {
 
         String intermediate = getIntermediate();
         builder.append("__Name__: `");
-        // Special cases like <init>, <clinit>, and other stuff required to have the same name by external libs
-        boolean isSpecial = original.equals(name);
-        if (!isSpecial) {
+        if (!isSpecial()) {
             builder.append(original)
                     .append(intermediate.isEmpty() || isClassMapping ? "" : "` => `" + intermediate).append("` => `");
         }
@@ -106,9 +104,17 @@ public class OfficialMapping implements Mapping {
         }
 
         if (getMemberClass() != null)
-            builder.append("__Type__: `").append(getMemberClass()).append("`");
+            builder.append("\n__Type__: `").append(getMemberClass()).append("`");
 
         return builder.toString();
+    }
+
+    /**
+     * Special methods like &lt;init&gt;, &lt;init&gt;, and other stuff required to have the same name by external libs
+     * @return True if the method is special (its original name equals its mapped name).
+     */
+    private boolean isSpecial() {
+        return original.equals(name);
     }
 
     @Override
@@ -150,8 +156,7 @@ public class OfficialMapping implements Mapping {
                         .orElse("");
             }
 
-            // Special cases like <init> and other stuff required to have the same name by external libs
-            if (srgs != null && intermediate.isEmpty() && original.equals(name)) {
+            if (srgs != null && intermediate.isEmpty() && isSpecial()) {
                 intermediate = original;
             }
         }

--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
@@ -32,9 +32,9 @@ public class OfficialMapping implements Mapping {
     private static final SignatureHelper sigHelper = new SignatureHelper();
 
     @ToString.Exclude
-    protected final transient FastSrgDatabase srgs;
+    private final FastSrgDatabase srgs;
     @ToString.Exclude
-    protected final transient OfficialDatabase db;
+    private final OfficialDatabase db;
 
     @Setter(AccessLevel.PACKAGE)
     @NonFinal
@@ -49,32 +49,49 @@ public class OfficialMapping implements Mapping {
     @Getter(onMethod = @__(@Override))
     private final String desc;
 
+    private final String parameters, returnType;
+
     @Getter(onMethod = @__(@Override))
     private final String original, name, memberClass;
 
     @ToString.Exclude
-    private final transient Map<NameType, String> mappedOwner = new EnumMap<>(NameType.class), mappedDesc = new EnumMap<>(NameType.class);
+    @Getter(AccessLevel.NONE)
+    private final Map<NameType, String> mappedDesc = new EnumMap<>(NameType.class);
 
     @NonFinal
     private String intermediate = null;
 
     @Override
     public String formatMessage(String mcver) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("\n");
-        builder.append("**MC " + mcver + ": " + (owner == null ? "" : owner.getName() + ".") + name + "**\n");
+        boolean isClassMapping = type == MappingType.CLASS;
+        StringBuilder builder = new StringBuilder("\n");
+        builder.append("**MC ").append(mcver).append(": ")
+                .append(owner == null ? "" : owner.getName() + ".").append(name).append("**\n");
+
         String intermediate = getIntermediate();
-        builder.append("__Name__: `" + original + (intermediate.isEmpty() ? "" : "` => `" + intermediate) + "` => `" + name + "`\n");
+        builder.append("__Name__: `");
+        // Special cases like <init>, <clinit>, and other stuff required to have the same name by external libs
+        boolean isSpecial = original.equals(name);
+        if (!isSpecial) {
+            builder.append(original)
+                    .append(intermediate.isEmpty() || isClassMapping ? "" : "` => `" + intermediate).append("` => `");
+        }
+        builder.append(name).append("`\n");
 
-        builder.append("__Side__: `" + side + "`");
+        builder.append("__Side__: `").append(side).append("`\n");
 
-        if (getType() != MappingType.PARAM && !intermediate.isEmpty()) {
-            builder.append("\n__AT__: `public ").append(Strings.nullToEmpty(getOwner(NameType.INTERMEDIATE)).replace('/', '.'));
+        if (type == MappingType.METHOD)
+            builder.append("__Descriptor__: `").append(returnType).append(' ')
+                    .append(name).append('(').append(parameters).append(")`\n");
+
+        if (!intermediate.isEmpty()) {
+            builder.append("__AT__: `public ").append(Strings.nullToEmpty(getOwner(NameType.INTERMEDIATE)).replace('/', '.'));
             String atName = intermediate;
-            if (getType() == MappingType.CLASS) {
+            if (isClassMapping) {
+                // getOwner() is empty here, so no space is needed
                 atName = atName.replace('/', '.');
             } else {
-                // If this is a class, then getOwner() is empty meaning we shouldn't add another space
+                // getOwner() isn't empty here, so we need an extra space
                 builder.append(' ');
             }
             builder.append(atName);
@@ -82,14 +99,14 @@ public class OfficialMapping implements Mapping {
             if (desc != null) {
                 builder.append(desc);
             }
-            if (getType() != MappingType.CLASS) {
+            if (!isClassMapping) {
                 builder.append(" # ").append(getName() == null ? intermediate : getName());
             }
             builder.append("`");
         }
 
         if (getMemberClass() != null)
-            builder.append("\n__Type__: `").append(getMemberClass()).append("`");
+            builder.append("__Type__: `").append(getMemberClass()).append("`");
 
         return builder.toString();
     }
@@ -101,7 +118,7 @@ public class OfficialMapping implements Mapping {
 
     @Override
     public @Nullable String getOwner(NameType name) {
-        return mappedOwner.computeIfAbsent(name, t -> owner == null ? null : sigHelper.mapType(t, owner.getOriginal(), this, db).getInternalName());
+        return owner == null ? null : name.get(owner);
     }
 
     private String mapType(NameType t, String type) {
@@ -116,7 +133,12 @@ public class OfficialMapping implements Mapping {
     @Override
     public String getIntermediate() {
         if (intermediate == null) {
-            if (type == MappingType.CLASS) {
+            // Should help with random issues
+            mappedDesc.clear();
+
+            if (srgs == null) {
+                intermediate = "";
+            } else if (type == MappingType.CLASS) {
                 intermediate = Optional.ofNullable(srgs.getClassMapping(original)).map(Mapping::getIntermediate).orElse("");
             } else {
                 String desc = getDesc(NameType.ORIGINAL);
@@ -126,6 +148,11 @@ public class OfficialMapping implements Mapping {
                         .findFirst()
                         .map(Mapping::getIntermediate)
                         .orElse("");
+            }
+
+            // Special cases like <init> and other stuff required to have the same name by external libs
+            if (srgs != null && intermediate.isEmpty() && original.equals(name)) {
+                intermediate = original;
             }
         }
 


### PR DESCRIPTION
This PR fixes some issues with official mappings and adds greater support for them including information about constructors and being able to use snapshot information.

* Support snapshots with official mappings and hardcode the first versions supported with official mappings so users cannot query invalid versions before official mappings were released
* Properly store information of unmapped data in official mappings like <init> and other methods required to have the same name by external libs inheritance
* Fix command hint to use `getName()`
* Fix `CommandMappings` sometimes replying incorrectly when updating guild settings with a flag
* Add `defaultStable` flag which is set to true in official mappings so that by default 1.16.5 is used instead of the latest snapshot when the field is unset for a guild.
* Fix manifest version info for official mappings
* Refactor display of official mappings and add more info like parameters and method descriptor