### PR TITLE
Create SrgDownloader and futureproof OfficialDownloader

### DIFF
--- a/src/main/java/com/tterrag/k9/K9.java
+++ b/src/main/java/com/tterrag/k9/K9.java
@@ -25,6 +25,7 @@ import com.tterrag.k9.logging.PrettifyMessageCreate;
 import com.tterrag.k9.mappings.Yarn2McpService;
 import com.tterrag.k9.mappings.mcp.McpDownloader;
 import com.tterrag.k9.mappings.official.OfficialDownloader;
+import com.tterrag.k9.mappings.srg.SrgDownloader;
 import com.tterrag.k9.mappings.yarn.YarnDownloader;
 import com.tterrag.k9.util.ConvertAdmins;
 import com.tterrag.k9.util.PaginatedMessageFactory;
@@ -184,7 +185,8 @@ public class K9 {
             */
             .service("Yarn Downloader", YarnDownloader.INSTANCE::start)
             .service("MCP Downloader", McpDownloader.INSTANCE::start)
-            .service("Official Downloader", OfficialDownloader.INSTANCE::start);
+            .service("Official Downloader", OfficialDownloader.INSTANCE::start)
+            .service("SRG Downloader", SrgDownloader.INSTANCE::start);
 
         if (args.yarn2mcpOutput != null) {
             final Yarn2McpService yarn2mcp = new Yarn2McpService(args.yarn2mcpOutput, args.yarn2mcpUser, args.yarn2mcpPass);

--- a/src/main/java/com/tterrag/k9/mappings/Yarn2McpService.java
+++ b/src/main/java/com/tterrag/k9/mappings/Yarn2McpService.java
@@ -25,6 +25,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.tterrag.k9.mappings.srg.SrgDownloader;
 import org.apache.commons.io.FileUtils;
 
 import com.google.common.base.Joiner;
@@ -38,8 +39,8 @@ import com.tterrag.k9.mappings.mcp.IntermediateMapping;
 import com.tterrag.k9.mappings.mcp.McpDownloader;
 import com.tterrag.k9.mappings.mcp.McpMapping;
 import com.tterrag.k9.mappings.mcp.McpMapping.Side;
-import com.tterrag.k9.mappings.mcp.SrgDatabase;
-import com.tterrag.k9.mappings.mcp.SrgMapping;
+import com.tterrag.k9.mappings.srg.SrgDatabase;
+import com.tterrag.k9.mappings.srg.SrgMapping;
 import com.tterrag.k9.mappings.yarn.YarnDownloader;
 import com.tterrag.k9.util.Monos;
 
@@ -153,8 +154,8 @@ public class Yarn2McpService {
     }
     
     private Mono<SrgDatabase> getSrgs(String version) {
-        return McpDownloader.INSTANCE.updateSrgs(version)
-                .then(Mono.fromCallable(() -> (SrgDatabase) new SrgDatabase(McpDownloader.INSTANCE, version).reload()));
+        return SrgDownloader.INSTANCE.updateSrgs(version)
+                .then(Mono.fromCallable(() -> (SrgDatabase) new SrgDatabase(version).reload()));
     }
     
     private Mono<Void> setupTempDir() {

--- a/src/main/java/com/tterrag/k9/mappings/mcp/McpDatabase.java
+++ b/src/main/java/com/tterrag/k9/mappings/mcp/McpDatabase.java
@@ -14,6 +14,8 @@ import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 
+import com.tterrag.k9.mappings.srg.SrgDatabase;
+import com.tterrag.k9.mappings.srg.SrgMapping;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -21,7 +23,6 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.tterrag.k9.mappings.AbstractMappingDatabase;
-import com.tterrag.k9.mappings.FastIntLookupDatabase;
 import com.tterrag.k9.mappings.Mapping;
 import com.tterrag.k9.mappings.MappingDatabase;
 import com.tterrag.k9.mappings.MappingType;
@@ -143,7 +144,7 @@ public class McpDatabase extends OverrideRemovingDatabase<McpMapping> {
         super(mcver);
     }
 
-    private final SrgDatabase srgs = new SrgDatabase(McpDownloader.INSTANCE, getMinecraftVersion());
+    private final SrgDatabase srgs = new SrgDatabase(getMinecraftVersion());
 
     @Override
     protected List<McpMapping> parseMappings() throws NoSuchVersionException, IOException {
@@ -187,7 +188,7 @@ public class McpDatabase extends OverrideRemovingDatabase<McpMapping> {
 
             // Add all srg mappings to this, if unmapped just use null/defaults
             for (MappingType type : MappingType.values()) {
-                Collection<com.tterrag.k9.mappings.mcp.SrgMapping> byType = srgs.lookup(NameType.INTERMEDIATE, type);
+                Collection<SrgMapping> byType = srgs.lookup(NameType.INTERMEDIATE, type);
                 for (SrgMapping srg : byType) {
                     McpMapping mapping;
                     Optional<@NonNull CsvMapping> csv = tempDb.lookup(NameType.INTERMEDIATE, type, srg.getIntermediate()).stream().sorted(Comparator.comparingInt(m -> m.getIntermediate().length())).findFirst();

--- a/src/main/java/com/tterrag/k9/mappings/mcp/McpDownloader.java
+++ b/src/main/java/com/tterrag/k9/mappings/mcp/McpDownloader.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 
+import com.tterrag.k9.mappings.srg.SrgDownloader;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
@@ -34,8 +35,6 @@ public class McpDownloader extends MappingDownloader<McpMapping, McpDatabase> {
     public static final McpDownloader INSTANCE = new McpDownloader();
 
     private static final String VERSION_JSON = "http://export.mcpbot.bspk.rs/versions.json";
-    private static final String SRGS_URL = "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/%1$s/mcp-%1$s-srg.zip";
-    private static final String TSRGS_URL = "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_config/%1$s/mcp_config-%1$s.zip";
     private static final String MAPPINGS_URL = "http://export.mcpbot.bspk.rs/%1$s/%2$d-%3$s/%1$s-%2$d-%3$s.zip";
     
     // Temporary 1.16 mappings data
@@ -82,7 +81,7 @@ public class McpDownloader extends MappingDownloader<McpMapping, McpDatabase> {
                 .then();
     }
     
-    private static int getMinVersion(String version) {
+    private int getMinVersion(String version) {
         String minversion = version.substring(version.indexOf('.') + 1, version.length());
         int seconddot = minversion.indexOf('.');
         if (seconddot != -1) {
@@ -90,57 +89,12 @@ public class McpDownloader extends MappingDownloader<McpMapping, McpDatabase> {
         }
         return Integer.parseInt(minversion);
     }
-    
-    public Mono<Void> updateSrgs(String version) {
-        return updateSrgs(this, version, getDataFolder());
-    }
-    
-    public static Mono<Void> updateSrgs(MappingDownloader<?, ?> downloader, String version, Path dataFolder) {
-        return Mono.fromCallable(() -> 
-        {
-            Path versionFolder = dataFolder.resolve(version);
-            
-            String urlpattern = SRGS_URL;
-            if (getMinVersion(version) >= 13) {
-                urlpattern = TSRGS_URL;
-            }
-            
-            log.info("Updating MCP data for for MC {}", version);
-            
-            // Download new SRGs if necessary
-            Path srgsFolder = versionFolder.resolve("srgs");
-            String srgsUrl = String.format(urlpattern, version);
-            URL url = new URL(srgsUrl);
-    
-            String filename = srgsUrl.substring(srgsUrl.lastIndexOf('/') + 1);
-            File md5File = srgsFolder.resolve(filename + ".md5").toFile();
-            File zipFile = srgsFolder.resolve(filename).toFile();
-    
-            boolean srgsUpToDate = false;
-            String md5 = IOUtils.toString(new URL(srgsUrl + ".md5").openStream(), Charsets.UTF_8);
-            if (md5File.exists() && zipFile.exists()) {
-                String localMd5 = Files.asCharSource(md5File, Charsets.UTF_8).readFirstLine();
-                if (md5.equals(localMd5)) {
-                    log.debug("MC {} SRGs up to date: {} == {}", version, md5, localMd5);
-                    srgsUpToDate = true;
-                }
-            }
-    
-            if (!srgsUpToDate) {
-                log.info("Found out of date or missing SRGs for MC {}. new MD5: {}", version, md5);
-                FileUtils.copyURLToFile(url, zipFile);
-                FileUtils.write(md5File, md5, Charsets.UTF_8);
-                downloader.remove(version);
-            }
-            return null;
-        });
-    }
-    
+
     @Override
     protected Mono<Void> checkUpdates(String version) {
         return updateVersions().then(Mono.fromSupplier(() -> this.versions))
                 .transform(Monos.mapOptional(vs -> vs.getMappings(version)))
-                .flatMap(mappings -> updateSrgs(version).thenReturn(mappings))
+                .flatMap(mappings -> SrgDownloader.INSTANCE.updateSrgs(version).thenReturn(mappings))
                 .flatMap(mappings -> Mono.fromCallable(() -> {
                 Path versionFolder = getDataFolder().resolve(version);
 

--- a/src/main/java/com/tterrag/k9/mappings/official/FastSrgDatabase.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/FastSrgDatabase.java
@@ -10,16 +10,16 @@ import com.tterrag.k9.mappings.MappingDownloader;
 import com.tterrag.k9.mappings.MappingType;
 import com.tterrag.k9.mappings.NameType;
 import com.tterrag.k9.mappings.NoSuchVersionException;
-import com.tterrag.k9.mappings.mcp.SrgDatabase;
-import com.tterrag.k9.mappings.mcp.SrgMapping;
+import com.tterrag.k9.mappings.srg.SrgDatabase;
+import com.tterrag.k9.mappings.srg.SrgMapping;
 
 public class FastSrgDatabase extends SrgDatabase {
 
     private final Map<String, SrgMapping> classMap = new HashMap<>();
     private final ListMultimap<String, SrgMapping> childrenMap = ArrayListMultimap.create();
 
-    public FastSrgDatabase(MappingDownloader<?, ?> parent, String mcver) throws NoSuchVersionException {
-        super(parent, mcver);
+    public FastSrgDatabase(String mcver) throws NoSuchVersionException {
+        super(mcver);
     }
 
     @Override

--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialDatabase.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialDatabase.java
@@ -18,14 +18,14 @@ import com.tterrag.k9.mappings.Mapping;
 import com.tterrag.k9.mappings.MappingType;
 import com.tterrag.k9.mappings.NoSuchVersionException;
 import com.tterrag.k9.mappings.mcp.McpMapping;
+import com.tterrag.k9.mappings.srg.SrgDatabase;
 
 public class OfficialDatabase extends AbstractMappingDatabase<OfficialMapping> {
     private final FastSrgDatabase srgs;
 
     public OfficialDatabase(String minecraftVersion) {
         super(minecraftVersion);
-        boolean isRelease = OfficialDownloader.INSTANCE.getManifest().getReleaseVersions().contains(minecraftVersion);
-        srgs = isRelease ? new FastSrgDatabase(OfficialDownloader.INSTANCE, minecraftVersion) : null;
+        srgs = SrgDatabase.srgExists(minecraftVersion) ? new FastSrgDatabase(minecraftVersion) : null;
     }
 
     @Override

--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialDownloader.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialDownloader.java
@@ -11,7 +11,7 @@ import org.apache.commons.io.FileUtils;
 
 import com.beust.jcommander.internal.Lists;
 import com.tterrag.k9.mappings.MappingDownloader;
-import com.tterrag.k9.mappings.mcp.McpDownloader;
+import com.tterrag.k9.mappings.srg.SrgDownloader;
 import com.tterrag.k9.util.annotation.Nullable;
 
 import lombok.Getter;
@@ -71,7 +71,7 @@ public class OfficialDownloader extends MappingDownloader<OfficialMapping, Offic
                 .filter(m -> this.getMinecraftVersionsInternal().contains(version))
                 .flatMap(m -> Mono.justOrEmpty(m.getVersionInfo(version)))
                 .flatMap(m -> m.getJson(getGson()))
-                .flatMap(mappings -> McpDownloader.updateSrgs(this, version, getDataFolder()).thenReturn(mappings))
+                .flatMap(m -> SrgDownloader.INSTANCE.updateSrgs(version).onErrorResume(e -> Mono.empty()).thenReturn(m))
                 .flatMap(versionJson -> Mono.fromCallable(() -> {
                     Path versionFolder = getDataFolder().resolve(version);
                     File mappingsFolder = versionFolder.resolve("mappings").toFile();

--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
@@ -147,6 +147,11 @@ public class OfficialMapping implements Mapping {
                 intermediate = "";
             } else if (type == MappingType.CLASS) {
                 intermediate = Optional.ofNullable(srgs.getClassMapping(original)).map(Mapping::getIntermediate).orElse("");
+                if (intermediate != null && intermediate.startsWith("net/minecraft/src/C_")) {
+                    // SRG classnames are purely used to make exports not contain mojmaps.
+                    // Remap to mojmap classnames here.
+                    intermediate = name;
+                }
             } else {
                 String desc = getDesc(NameType.ORIGINAL);
                 intermediate = srgs.getChildren(owner.getOriginal()).stream()

--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
@@ -26,7 +26,7 @@ import lombok.experimental.NonFinal;
 
 @Value
 @RequiredArgsConstructor
-@EqualsAndHashCode(of = {"type", "owner", "original", "name"})
+@EqualsAndHashCode(of = {"type", "owner", "original", "name", "desc"})
 @ToString(doNotUseGetters = true)
 public class OfficialMapping implements Mapping {
     private static final SignatureHelper sigHelper = new SignatureHelper();

--- a/src/main/java/com/tterrag/k9/mappings/srg/SrgDownloader.java
+++ b/src/main/java/com/tterrag/k9/mappings/srg/SrgDownloader.java
@@ -1,0 +1,104 @@
+package com.tterrag.k9.mappings.srg;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import com.google.gson.GsonBuilder;
+import com.tterrag.k9.mappings.DeserializeIntArrayList;
+import com.tterrag.k9.mappings.MappingDownloader;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import reactor.core.publisher.Mono;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
+
+@Slf4j
+public class SrgDownloader extends MappingDownloader<SrgMapping, SrgDatabase> {
+    public static final SrgDownloader INSTANCE = new SrgDownloader();
+
+    private static final String SRGS_URL = "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/%1$s/mcp-%1$s-srg.zip";
+    private static final String TSRGS_URL = "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_config/%1$s/mcp_config-%1$s.zip";
+
+    private SrgDownloader() {
+        super("srg", SrgDatabase::new, 1);
+    }
+
+    @Override
+    protected Set<String> getMinecraftVersionsInternal() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    protected String getLatestMinecraftVersionInternal(boolean stable) {
+        return "Unknown";
+    }
+
+    @Override
+    protected void collectParsers(GsonBuilder builder) {
+        super.collectParsers(builder);
+        DeserializeIntArrayList.register(builder);
+    }
+
+    @Override
+    protected Mono<Void> updateVersions() {
+        return Mono.empty();
+    }
+
+    private int getMinVersion(String version) {
+        String minversion = version.substring(version.indexOf('.') + 1);
+        int seconddot = minversion.indexOf('.');
+        if (seconddot != -1) {
+            minversion = minversion.substring(0, seconddot);
+        }
+        return Integer.parseInt(minversion);
+    }
+
+    public Mono<Void> updateSrgs(String version) {
+        return Mono.fromCallable(() -> {
+            Path versionFolder = getDataFolder().resolve(version);
+
+            String urlpattern = SRGS_URL;
+            if (getMinVersion(version) >= 13) {
+                urlpattern = TSRGS_URL;
+            }
+
+            log.info("Updating SRG data for for MC {}", version);
+
+            // Download new SRGs if necessary
+            Path srgsFolder = versionFolder.resolve("srgs");
+            String srgsUrl = String.format(urlpattern, version);
+            URL url = new URL(srgsUrl);
+
+            String filename = srgsUrl.substring(srgsUrl.lastIndexOf('/') + 1);
+            File md5File = srgsFolder.resolve(filename + ".md5").toFile();
+            File zipFile = srgsFolder.resolve(filename).toFile();
+
+            boolean srgsUpToDate = false;
+            String md5 = IOUtils.toString(new URL(srgsUrl + ".md5").openStream(), Charsets.UTF_8);
+            if (md5File.exists() && zipFile.exists()) {
+                String localMd5 = Files.asCharSource(md5File, Charsets.UTF_8).readFirstLine();
+                if (md5.equals(localMd5)) {
+                    log.debug("MC {} SRGs up to date: {} == {}", version, md5, localMd5);
+                    srgsUpToDate = true;
+                }
+            }
+
+            if (!srgsUpToDate) {
+                log.info("Found out of date or missing SRGs for MC {}. new MD5: {}", version, md5);
+                FileUtils.copyURLToFile(url, zipFile);
+                FileUtils.write(md5File, md5, Charsets.UTF_8);
+                remove(version);
+            }
+            return null;
+        });
+    }
+
+    @Override
+    protected Mono<Void> checkUpdates(String version) {
+        return updateSrgs(version);
+    }
+}

--- a/src/main/java/com/tterrag/k9/mappings/srg/SrgMapping.java
+++ b/src/main/java/com/tterrag/k9/mappings/srg/SrgMapping.java
@@ -1,9 +1,10 @@
-package com.tterrag.k9.mappings.mcp;
+package com.tterrag.k9.mappings.srg;
 
 import com.tterrag.k9.mappings.MappingDatabase;
 import com.tterrag.k9.mappings.MappingType;
 import com.tterrag.k9.mappings.NameType;
 import com.tterrag.k9.mappings.SignatureHelper;
+import com.tterrag.k9.mappings.mcp.IntermediateMapping;
 import com.tterrag.k9.util.annotation.Nullable;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/com/tterrag/k9/mappings/srg/SrgParser.java
+++ b/src/main/java/com/tterrag/k9/mappings/srg/SrgParser.java
@@ -1,4 +1,4 @@
-package com.tterrag.k9.mappings.mcp;
+package com.tterrag.k9.mappings.srg;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/tterrag/k9/mappings/srg/TsrgParser.java
+++ b/src/main/java/com/tterrag/k9/mappings/srg/TsrgParser.java
@@ -46,6 +46,7 @@ public class TsrgParser implements Parser<ZipFile, SrgMapping> {
         }
         List<SrgMapping> ret = new ArrayList<>();
         SrgMapping currentClass = null;
+        int fieldNumber = 2;
         for (String line : lines) {
             SrgMapping mapping;
             if (line.startsWith("tsrg2 ")) {
@@ -53,6 +54,8 @@ public class TsrgParser implements Parser<ZipFile, SrgMapping> {
                 if (!line.startsWith("tsrg2 obf srg")) {
                     throw new UnsupportedOperationException("Custom names in tsrgv2 is not supported yet");
                 }
+                // So we can support extra names on the end, e.g. "obf srg id" which is present in newer MCPConfig exports
+                fieldNumber = line.split(" ").length - 1;
                 continue;
             }
             if (!line.startsWith("\t")) {
@@ -60,7 +63,7 @@ public class TsrgParser implements Parser<ZipFile, SrgMapping> {
                 mapping = currentClass = new SrgMapping(db, MappingType.CLASS, names[0], names[1], null, null, null);
             } else if (!line.startsWith("\t\t")) {
                 String[] data = line.substring(1).split(" ");
-                if (data.length == 2) {
+                if (data.length == fieldNumber) {
                     mapping = new SrgMapping(db, MappingType.FIELD, data[0], data[1], null, null, currentClass.getIntermediate());
                 } else {
                     // TSRGv2 Support

--- a/src/main/java/com/tterrag/k9/mappings/srg/TsrgParser.java
+++ b/src/main/java/com/tterrag/k9/mappings/srg/TsrgParser.java
@@ -1,4 +1,4 @@
-package com.tterrag.k9.mappings.mcp;
+package com.tterrag.k9.mappings.srg;
 
 import java.io.IOException;
 import java.util.ArrayList;


### PR DESCRIPTION
SrgDownloader is now used to download SRG files to a shared folder instead of duplicating data in existing downloader folders and has been moved out of McpDownloader. Srg-related classes have been moved to a separate `srg` package. Mojmaps now checks if a given SRG version exists locally when creating the FastSrgDatabase, and if there are errors when downloading a SRG version in updateVersion in OfficialDownloader, it swallows the exception and handles it by not loading SRG for the given version. A check is now added if classnames start with `net/minecraft/src/C_` as that means the SRG name is the mojmap classname, so it is remapped. This fixes AT output on 1.17+.