### PR TITLE
Re-Add forgotten return statement

### DIFF
--- a/src/main/java/com/tterrag/k9/mappings/mcp/SrgParser.java
+++ b/src/main/java/com/tterrag/k9/mappings/mcp/SrgParser.java
@@ -92,6 +92,7 @@ public class SrgParser implements Parser<ZipFile, SrgMapping> {
                 if (staticMethods.contains(srg)) {
                     ret.setStatic(true);
                 }
+                return ret;
             default:
                 throw new IllegalArgumentException("Invalid type");
         }


### PR DESCRIPTION
In commit https://github.com/tterrag1098/K9/commit/4290e4ef727fb47de8bb65034ab5109df3fd0692 a return statement was forgotten which prevented MCP mappings from being looked up for versions that are 1.12 and older.

I didn't test it but it's a 1 line change and based on the error given when looking up mappings for versions that are 1.12 and older the missing return statement seems to be the issue.