### PR TITLE
Fix AT format for 1.21+ mappings by using reamapped names instead of obfuscated IDs

### DIFF
--- a/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
+++ b/src/main/java/com/tterrag/k9/mappings/official/OfficialMapping.java
@@ -83,9 +83,13 @@ public class OfficialMapping implements Mapping {
                     .append(name).append('(').append(parameters).append(")`\n");
         }
 
-        if (!intermediate.isEmpty()) {
+        boolean is121Plus = mcver != null && mcver.compareTo("1.21") >= 0;
+
+        // For 1.21+, use the remapped name. For older versions, use intermediate.
+        String atName = is121Plus ? name : intermediate;
+
+        if (!intermediate.isEmpty() || is121Plus) {
             builder.append("__AT__: `public ").append(Strings.nullToEmpty(getOwner(NameType.INTERMEDIATE)).replace('/', '.'));
-            String atName = intermediate;
             if (isClassMapping) {
                 // getOwner() is empty here, so no space is needed
                 atName = atName.replace('/', '.');


### PR DESCRIPTION
This PR fixes an issue with access transformer formatting specifically for Minecraft 1.21+ mappings where obfuscated identifiers (like f_315710_ or m_132831_) were being used in AT lines instead of their remapped counterparts.

NeoForge now uses remapped names directly in their access transformers for 1.21+, so this update ensures K9 properly displays AT lines with readable names rather than obfuscated IDs.